### PR TITLE
Include python2 by shell to bootstrap for ansible

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -42,6 +42,16 @@
             "shutdown_command": "systemctl start poweroff.timer"
         }
     ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "sleep 30",
+                "sudo pacman --noconfirm -Syu",
+                "sudo pacman --noconfirm -S python2"
+            ]
+        }
+    ],
     "post-processors": [
         {
             "type": "vagrant",


### PR DESCRIPTION
Include python2 by shell provisioner to allow easy ansible testing. Plays nice with those of us only using the vagrant provisioner without the extra bootstrapping script.
