### PR TITLE
guest_additions_mode fix

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -11,7 +11,7 @@
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "{{user `iso_checksum_type`}}",
             "guest_os_type": "ArchLinux_64",
-            "guest_additions_attach": "true",
+            "guest_additions_mode": "attach",
             "http_directory": ".",
             "boot_wait": "5s",
             "boot_command": [


### PR DESCRIPTION
There seems to be a small typo or error in your arch-template.json as of Packer v0.3.11.
