### PR TITLE
fixed for packer 0.5.0

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -6,7 +6,7 @@
     },
     "builders": [
         {
-            "type": "virtualbox",
+            "type": "virtualbox-iso",
             "iso_url": "{{user `iso_url`}}",
             "iso_checksum": "{{user `iso_checksum`}}",
             "iso_checksum_type": "{{user `iso_checksum_type`}}",
@@ -22,7 +22,11 @@
             "disk_size": 20480,
             "ssh_username": "root",
             "ssh_password": "vagrant",
-            "shutdown_command": "systemctl start poweroff.timer"
+            "shutdown_command": "systemctl start poweroff.timer",
+	    "vboxmanage": [
+              [ "modifyvm", "{{.Name}}", "--memory", "1024" ],
+              [ "modifyvm", "{{.Name}}", "--cpus", "2" ]
+            ]
         },
         {
             "type": "vmware",


### PR DESCRIPTION
Packer now uses virtualbox-iso or virtualbox-ovf.  In order to get packer build to work, in the builders section I had to change virtualbox to virtualbox-iso.   

I also added vboxmanage section to specify memory and cpus used. (feel free to ignore or use)
