### PR TITLE
Enable dhcpcd

### DIFF
--- a/install-virtualbox.sh
+++ b/install-virtualbox.sh
@@ -51,10 +51,8 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
 	/usr/bin/locale-gen
 	/usr/bin/mkinitcpio -p linux
 	/usr/bin/usermod --password ${PASSWORD} root
-	# https://wiki.archlinux.org/index.php/Network_Configuration#Device_names
-	/usr/bin/ln -s /dev/null /etc/udev/rules.d/80-net-name-slot.rules
-	/usr/bin/ln -s '/usr/lib/systemd/system/dhcpcd@.service' '/etc/systemd/system/multi-user.target.wants/dhcpcd@eth0.service'
 	/usr/bin/sed -i 's/#UseDNS yes/UseDNS no/' /etc/ssh/sshd_config
+	/usr/bin/systemctl enable dhcpcd.service
 	/usr/bin/systemctl enable sshd.service
 
 	# VirtualBox Guest Additions


### PR DESCRIPTION
When doing the packer build, packer got stuck on "waiting for ssh to become available". This seems to be resolved by enabling dhcpcd.

Well I just noticed vagrant needs the eth0.. naming.
