### PR TITLE
curl should follow redirect. fixes #14

### DIFF
--- a/install-virtualbox.sh
+++ b/install-virtualbox.sh
@@ -73,7 +73,7 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
 	echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant
 	/usr/bin/chmod 0440 /etc/sudoers.d/10_vagrant
 	/usr/bin/install --directory --owner=vagrant --group=users --mode=0700 /home/vagrant/.ssh
-	/usr/bin/curl --output /home/vagrant/.ssh/authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
+	/usr/bin/curl -L --output /home/vagrant/.ssh/authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
 	/usr/bin/chown vagrant:users /home/vagrant/.ssh/authorized_keys
 	/usr/bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
 


### PR DESCRIPTION
The original github vagrant.pub url now returns a 301, we need to tell curl to follow the redirect.
