### PR TITLE
Add parallels support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-packer_arch_virtualbox.box
-packer_arch_vmware.box
+packer_arch_*.box
 packer_cache
 output-vmware

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Packer Arch
 Packer Arch is a bare bones [Packer](http://www.packer.io/) template and
 installation script that can be used to generate a [Vagrant](http://www.vagrantup.com/)
 base box for [Arch Linux](https://www.archlinux.org/). The template works
-with both the default VirtualBox provider as well as the
-[VMware provider](http://www.vagrantup.com/vmware).
+with the default VirtualBox provider as well as with
+[VMware](http://www.vagrantup.com/vmware) and [Parallels](https://github.com/Parallels/vagrant-parallels) providers.
 
 Overview
 --------
@@ -59,6 +59,21 @@ this repo and go:
 Then you can import the generated box into Vagrant:
 
     $ vagrant box add arch packer_arch_vmware.box
+
+### Parallels Provider
+
+Assuming that you already have Packer,
+[Parallels](http://www.parallels.com/), [Parallels SDK](http://www.parallels.com/eu/products/desktop/download/) and
+Vagrant with the Parallels provider installed, you should be good to clone
+this repo and go:
+
+    $ git clone https://github.com/elasticdog/packer-arch.git
+    $ cd packer-arch/
+    $ packer build -only=parallels-iso arch-template.json
+
+Then you can import the generated box into Vagrant:
+
+    $ vagrant box add arch packer_arch_parallels.box
 
 Known Issues
 ------------

--- a/arch-template.json
+++ b/arch-template.json
@@ -22,9 +22,9 @@
             ],
             "disk_size": 20480,
             "hard_drive_interface": "sata",
-            "ssh_username": "root",
+            "ssh_username": "vagrant",
             "ssh_password": "vagrant",
-            "shutdown_command": "systemctl start poweroff.timer"
+            "shutdown_command": "sudo systemctl start poweroff.timer"
         },
         {
             "type": "vmware-iso",
@@ -40,9 +40,9 @@
                 "/usr/bin/bash ./install-vmware.sh<enter>"
             ],
             "disk_size": 20480,
-            "ssh_username": "root",
+            "ssh_username": "vagrant",
             "ssh_password": "vagrant",
-            "shutdown_command": "systemctl start poweroff.timer"
+            "shutdown_command": "sudo systemctl start poweroff.timer"
         }
     ],
     "post-processors": [

--- a/arch-template.json
+++ b/arch-template.json
@@ -43,6 +43,28 @@
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
             "shutdown_command": "sudo systemctl start poweroff.timer"
+        },
+        {
+            "type": "parallels-iso",
+            "parallels_tools_flavor": "lin",
+            "parallels_tools_mode": "attach",
+            "guest_os_type": "linux-2.6",
+            "iso_url": "{{user `iso_url`}}",
+            "iso_checksum": "{{user `iso_checksum`}}",
+            "iso_checksum_type": "{{user `iso_checksum_type`}}",
+            "http_directory": ".",
+            "boot_wait": "5s",
+            "boot_command": [
+                "<enter><wait10><wait10>",
+                "/usr/bin/curl -O http://{{.HTTPIP}}:{{.HTTPPort}}/install-parallels.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{.HTTPIP}}:{{.HTTPPort}}/poweroff.timer<enter><wait5>",
+                "/usr/bin/curl -O http://{{.HTTPIP}}:{{.HTTPPort}}/parallels_tools.sh<enter><wait5>",
+                "/usr/bin/bash ./install-parallels.sh<enter>"
+            ],
+            "disk_size": 20480,
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "shutdown_command": "sudo /parallels_tools.sh && sudo rm /parallels_tools.sh && sudo systemctl start poweroff.timer"
         }
     ],
     "post-processors": [

--- a/install-parallels.sh
+++ b/install-parallels.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+DISK='/dev/sda'
+FQDN='vagrant-arch.vagrantup.com'
+KEYMAP='us'
+LANGUAGE='en_US.UTF-8'
+PASSWORD=$(/usr/bin/openssl passwd -crypt 'vagrant')
+TIMEZONE='UTC'
+
+CONFIG_SCRIPT='/usr/local/bin/arch-config.sh'
+ROOT_PARTITION="${DISK}1"
+TARGET_DIR='/mnt'
+
+echo "==> clearing partition table on ${DISK}"
+/usr/bin/sgdisk --zap ${DISK}
+
+echo "==> destroying magic strings and signatures on ${DISK}"
+/usr/bin/dd if=/dev/zero of=${DISK} bs=512 count=2048
+/usr/bin/wipefs --all ${DISK}
+
+echo "==> creating /root partition on ${DISK}"
+/usr/bin/sgdisk --new=1:0:0 ${DISK}
+
+echo "==> setting ${DISK} bootable"
+/usr/bin/sgdisk ${DISK} --attributes=1:set:2
+
+echo '==> creating /root filesystem (ext4)'
+/usr/bin/mkfs.ext4 -F -m 0 -q -L root ${ROOT_PARTITION}
+
+echo "==> mounting ${ROOT_PARTITION} to ${TARGET_DIR}"
+/usr/bin/mount -o noatime,errors=remount-ro ${ROOT_PARTITION} ${TARGET_DIR}
+
+echo '==> bootstrapping the base installation'
+/usr/bin/pacstrap ${TARGET_DIR} base base-devel
+/usr/bin/arch-chroot ${TARGET_DIR} pacman -S --noconfirm gptfdisk openssh syslinux
+/usr/bin/arch-chroot ${TARGET_DIR} syslinux-install_update -i -a -m
+/usr/bin/sed -i 's/sda3/sda1/' "${TARGET_DIR}/boot/syslinux/syslinux.cfg"
+/usr/bin/sed -i 's/TIMEOUT 50/TIMEOUT 10/' "${TARGET_DIR}/boot/syslinux/syslinux.cfg"
+
+echo '==> generating the filesystem table'
+/usr/bin/genfstab -p ${TARGET_DIR} >> "${TARGET_DIR}/etc/fstab"
+
+echo '==> generating the system configuration script'
+/usr/bin/install --mode=0755 /dev/null "${TARGET_DIR}${CONFIG_SCRIPT}"
+
+cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
+	echo '${FQDN}' > /etc/hostname
+	/usr/bin/ln -s /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
+	echo 'KEYMAP=${KEYMAP}' > /etc/vconsole.conf
+	/usr/bin/sed -i 's/#${LANGUAGE}/${LANGUAGE}/' /etc/locale.gen
+	/usr/bin/locale-gen
+	/usr/bin/mkinitcpio -p linux
+	/usr/bin/usermod --password ${PASSWORD} root
+	# https://wiki.archlinux.org/index.php/Network_Configuration#Device_names
+	/usr/bin/ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
+	/usr/bin/ln -s '/usr/lib/systemd/system/dhcpcd@.service' '/etc/systemd/system/multi-user.target.wants/dhcpcd@eth0.service'
+	/usr/bin/sed -i 's/#UseDNS yes/UseDNS no/' /etc/ssh/sshd_config
+	/usr/bin/systemctl enable sshd.service
+
+	# Vagrant-specific configuration
+	/usr/bin/useradd --password ${PASSWORD} --comment 'Vagrant User' --create-home --gid users vagrant
+	echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_vagrant
+	echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant
+	/usr/bin/chmod 0440 /etc/sudoers.d/10_vagrant
+	/usr/bin/install --directory --owner=vagrant --group=users --mode=0700 /home/vagrant/.ssh
+	/usr/bin/curl --output /home/vagrant/.ssh/authorized_keys --location https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
+	/usr/bin/chown vagrant:users /home/vagrant/.ssh/authorized_keys
+	/usr/bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
+
+	# clean up
+	/usr/bin/pacman -Rcns --noconfirm gptfdisk
+	/usr/bin/pacman -Scc --noconfirm
+EOF
+
+echo '==> entering chroot and configuring system'
+/usr/bin/arch-chroot ${TARGET_DIR} ${CONFIG_SCRIPT}
+rm "${TARGET_DIR}${CONFIG_SCRIPT}"
+
+# http://comments.gmane.org/gmane.linux.arch.general/48739
+echo '==> adding workaround for shutdown race condition'
+/usr/bin/install --mode=0644 poweroff.timer "${TARGET_DIR}/etc/systemd/system/poweroff.timer"
+
+echo '==> Include parallels tools'
+/usr/bin/install --mode=0755 parallels_tools.sh "${TARGET_DIR}/parallels_tools.sh"
+
+echo '==> installation complete!'
+/usr/bin/sleep 3
+/usr/bin/umount ${TARGET_DIR}
+/usr/bin/systemctl reboot

--- a/parallels_tools.sh
+++ b/parallels_tools.sh
@@ -1,0 +1,15 @@
+# Install parallels tools (https://wiki.archlinux.org/index.php/Parallels)
+mount /dev/sr1 /mnt
+ln -sf /usr/lib/systemd/scripts/ /etc/init.d
+export def_sysconfdir=/etc/init.d
+touch /etc/X11/xorg.conf
+pacman -S --noconfirm python2 linux-headers
+ln -sf /usr/bin/python2 /usr/local/bin/python
+/mnt/install --install-unattended
+
+# Cleanup after parallels tools installation
+umount /dev/sr1
+/usr/bin/pacman -Rcns --noconfirm python2 linux-headers
+rm -f /etc/init.d
+rm -f /etc/X11/xorg.conf
+rm -f /usr/local/bin/python


### PR DESCRIPTION
This change would allow one to use parallels as a provider.

I noticed that default installation of ssh prevents user to login using 'root' so I just switched to 'vagrant' and pre-appended 'sudo' where necessary.

I also didn't thought of a way to install parallels tools without rebooting the VM, so the installation process ended up within 'shutdown_command' section.