### PR TITLE
Update ISO

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2015.10.01/archlinux-2015.10.01-dual.iso",
-        "iso_checksum": "6d95a2a35e29b23d6abd30011c6ab8220250efb6",
+        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2015.11.01/archlinux-2015.11.01-dual.iso",
+        "iso_checksum": "de1876320317586ec84259df3bc3cfbafcf3242c",
         "iso_checksum_type": "sha1"
     },
     "builders": [


### PR DESCRIPTION
Update ISO url for November.

Not sure if this is still necessary because of the wrapper scripts.
However, I figured if one wants to simply grab the `arch-template.json` file and get running without any support scripts, this will still allow them to do so.