### PR TITLE
Store the output *.box files in a dedicated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-packer_arch_*.box
+output/*.box
 packer_cache
-output-vmware

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ should be good to clone this repo and go:
 
 Then you can import the generated box into Vagrant:
 
-    $ vagrant box add arch packer_arch_virtualbox.box
+    $ vagrant box add arch output/packer_arch_virtualbox.box
 
 ### VMware Provider
 
@@ -58,7 +58,7 @@ this repo and go:
 
 Then you can import the generated box into Vagrant:
 
-    $ vagrant box add arch packer_arch_vmware.box
+    $ vagrant box add arch output/packer_arch_vmware.box
 
 ### Parallels Provider
 
@@ -73,7 +73,7 @@ this repo and go:
 
 Then you can import the generated box into Vagrant:
 
-    $ vagrant box add arch packer_arch_parallels.box
+    $ vagrant box add arch output/packer_arch_parallels.box
 
 ### wrapacker
 

--- a/arch-template.json
+++ b/arch-template.json
@@ -74,7 +74,7 @@
     "post-processors": [
         {
             "type": "vagrant",
-            "output": "packer_arch_{{.Provider}}.box"
+            "output": "output/packer_arch_{{.Provider}}.box"
         }
     ]
 }


### PR DESCRIPTION
Tidy things up a bit by not polluting the top-level directory.