### PR TITLE
Add a headless option in arch-template

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -48,7 +48,8 @@
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
             "ssh_timeout": "{{ user `ssh_timeout` }}",
-            "shutdown_command": "sudo systemctl start poweroff.timer"
+            "shutdown_command": "sudo systemctl start poweroff.timer",
+            "headless" : "{{ user `headless`}}"
         },
         {
             "type": "vmware-iso",


### PR DESCRIPTION
I'm using vagrant on my headless server, this option allows to create boxes on headless server.
It's not going to change anything if you do not specify var headless option. By default headless is set to false when virtualbox is used as builder.

usage: packer build -only=virtualbox-iso -var headless=true arch-template.json