### PR TITLE
Revert "Update to August 2016 ISO"

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2016.08.01/archlinux-2016.08.01-dual.iso",
-        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/2016.08.01/sha1sums.txt",
+        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2016.07.01/archlinux-2016.07.01-dual.iso",
+        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/2016.07.01/sha1sums.txt",
         "iso_checksum_type": "sha1",
         "ssh_timeout": "20m"
     },


### PR DESCRIPTION
This reverts commit d93e04754a4a5f4c7b40d7935dae8797151b200c.

August 2016 ISO image could not boot with `Failed to load ldlinux.c32`
message.
We should revert this change.

Fixes #49.