### PR TITLE
Move Provisioning to STDOUT

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -18,9 +18,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/enable-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-ssh.sh<enter>"
+                "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "ssh_username": "vagrant",
@@ -39,9 +39,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/enable-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-ssh.sh<enter>"
+                "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "hard_drive_interface": "sata",
@@ -60,9 +60,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/enable-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-ssh.sh<enter>"
+                "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "ssh_username": "vagrant",

--- a/arch-template.json
+++ b/arch-template.json
@@ -18,9 +18,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-base.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-base.sh<enter>"
+                "/usr/bin/bash ./install-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "ssh_username": "vagrant",
@@ -39,9 +39,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-base.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-base.sh<enter>"
+                "/usr/bin/bash ./install-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "hard_drive_interface": "sata",
@@ -60,9 +60,9 @@
             "boot_wait": "5s",
             "boot_command": [
                 "<enter><wait10><wait10>",
-                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-base.sh<enter><wait5>",
+                "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/install-ssh.sh<enter><wait5>",
                 "/usr/bin/curl -O http://{{ .HTTPIP }}:{{ .HTTPPort }}/poweroff.timer<enter><wait5>",
-                "/usr/bin/bash ./install-base.sh<enter>"
+                "/usr/bin/bash ./install-ssh.sh<enter>"
             ],
             "disk_size": 20480,
             "ssh_username": "vagrant",
@@ -72,6 +72,11 @@
         }
     ],
     "provisioners": [
+        {
+            "type": "shell",
+            "execute_command": "{{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+            "script": "scripts/install-base.sh"
+        },
         {
             "only": ["parallels-iso"],
             "type": "shell",

--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -11,36 +11,36 @@ CONFIG_SCRIPT='/usr/local/bin/arch-config.sh'
 ROOT_PARTITION="${DISK}1"
 TARGET_DIR='/mnt'
 
-echo "==> clearing partition table on ${DISK}"
+echo "==> Clearing partition table on ${DISK}"
 /usr/bin/sgdisk --zap ${DISK}
 
-echo "==> destroying magic strings and signatures on ${DISK}"
+echo "==> Destroying magic strings and signatures on ${DISK}"
 /usr/bin/dd if=/dev/zero of=${DISK} bs=512 count=2048
 /usr/bin/wipefs --all ${DISK}
 
-echo "==> creating /root partition on ${DISK}"
+echo "==> Creating /root partition on ${DISK}"
 /usr/bin/sgdisk --new=1:0:0 ${DISK}
 
-echo "==> setting ${DISK} bootable"
+echo "==> Setting ${DISK} bootable"
 /usr/bin/sgdisk ${DISK} --attributes=1:set:2
 
-echo '==> creating /root filesystem (ext4)'
+echo '==> Creating /root filesystem (ext4)'
 /usr/bin/mkfs.ext4 -O ^64bit -F -m 0 -q -L root ${ROOT_PARTITION}
 
-echo "==> mounting ${ROOT_PARTITION} to ${TARGET_DIR}"
+echo "==> Mounting ${ROOT_PARTITION} to ${TARGET_DIR}"
 /usr/bin/mount -o noatime,errors=remount-ro ${ROOT_PARTITION} ${TARGET_DIR}
 
-echo '==> bootstrapping the base installation'
+echo '==> Bootstrapping the base installation'
 /usr/bin/pacstrap ${TARGET_DIR} base base-devel
 /usr/bin/arch-chroot ${TARGET_DIR} pacman -S --noconfirm gptfdisk openssh syslinux
 /usr/bin/arch-chroot ${TARGET_DIR} syslinux-install_update -i -a -m
 /usr/bin/sed -i 's/sda3/sda1/' "${TARGET_DIR}/boot/syslinux/syslinux.cfg"
 /usr/bin/sed -i 's/TIMEOUT 50/TIMEOUT 10/' "${TARGET_DIR}/boot/syslinux/syslinux.cfg"
 
-echo '==> generating the filesystem table'
+echo '==> Generating the filesystem table'
 /usr/bin/genfstab -p ${TARGET_DIR} >> "${TARGET_DIR}/etc/fstab"
 
-echo '==> generating the system configuration script'
+echo '==> Generating the system configuration script'
 /usr/bin/install --mode=0755 /dev/null "${TARGET_DIR}${CONFIG_SCRIPT}"
 
 cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
@@ -71,15 +71,15 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
 	/usr/bin/pacman -Rcns --noconfirm gptfdisk
 EOF
 
-echo '==> entering chroot and configuring system'
+echo '==> Entering chroot and configuring system'
 /usr/bin/arch-chroot ${TARGET_DIR} ${CONFIG_SCRIPT}
 rm "${TARGET_DIR}${CONFIG_SCRIPT}"
 
 # http://comments.gmane.org/gmane.linux.arch.general/48739
-echo '==> adding workaround for shutdown race condition'
-/usr/bin/install --mode=0644 poweroff.timer "${TARGET_DIR}/etc/systemd/system/poweroff.timer"
+echo '==> Adding workaround for shutdown race condition'
+/usr/bin/install --mode=0644 /root/poweroff.timer "${TARGET_DIR}/etc/systemd/system/poweroff.timer"
 
-echo '==> installation complete!'
+echo '==> Installation complete!'
 /usr/bin/sleep 3
 /usr/bin/umount ${TARGET_DIR}
 /usr/bin/systemctl reboot

--- a/srv/enable-ssh.sh
+++ b/srv/enable-ssh.sh
@@ -8,9 +8,4 @@ echo "==> Enabling SSH"
 echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_vagrant
 echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant
 /usr/bin/chmod 0440 /etc/sudoers.d/10_vagrant
-/usr/bin/install --directory --owner=vagrant --group=users --mode=0700 /home/vagrant/.ssh
-/usr/bin/curl --output /home/vagrant/.ssh/authorized_keys --location https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
-/usr/bin/chown vagrant:users /home/vagrant/.ssh/authorized_keys
-/usr/bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
 /usr/bin/systemctl start sshd.service
-

--- a/srv/install-ssh.sh
+++ b/srv/install-ssh.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+PASSWORD=$(/usr/bin/openssl passwd -crypt 'vagrant')
+
+echo "==> Enabling SSH"
+# Vagrant-specific configuration
+/usr/bin/useradd --password ${PASSWORD} --comment 'Vagrant User' --create-home --gid users vagrant
+echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_vagrant
+echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant
+/usr/bin/chmod 0440 /etc/sudoers.d/10_vagrant
+/usr/bin/install --directory --owner=vagrant --group=users --mode=0700 /home/vagrant/.ssh
+/usr/bin/curl --output /home/vagrant/.ssh/authorized_keys --location https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
+/usr/bin/chown vagrant:users /home/vagrant/.ssh/authorized_keys
+/usr/bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
+/usr/bin/systemctl start sshd.service
+


### PR DESCRIPTION
Previously, there was an issue with mkfs failing due to a missing options flag (seen [here](https://github.com/elasticdog/packer-arch/issues/49)).

This error was difficult to catch, as it was only output in the provisioned OS's virtual machine file, which gets cleared when the machine reboots.

This change moves the base installation steps to be more in line with the other provisioning steps, and allows for any errors, issues, or output to be cached in the logs of the interface running the Packer build.
