### PR TITLE
Create vagrant user in vagrant group

### DIFF
--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -58,13 +58,13 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
 	/usr/bin/systemctl enable sshd.service
 
 	# Vagrant-specific configuration
-	/usr/bin/useradd --password ${PASSWORD} --comment 'Vagrant User' --create-home --gid users vagrant
+	/usr/bin/useradd --password ${PASSWORD} --comment 'Vagrant User' --create-home --user-group vagrant
 	echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_vagrant
 	echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant
 	/usr/bin/chmod 0440 /etc/sudoers.d/10_vagrant
-	/usr/bin/install --directory --owner=vagrant --group=users --mode=0700 /home/vagrant/.ssh
+	/usr/bin/install --directory --owner=vagrant --group=vagrant --mode=0700 /home/vagrant/.ssh
 	/usr/bin/curl --output /home/vagrant/.ssh/authorized_keys --location https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub
-	/usr/bin/chown vagrant:users /home/vagrant/.ssh/authorized_keys
+	/usr/bin/chown vagrant:vagrant /home/vagrant/.ssh/authorized_keys
 	/usr/bin/chmod 0600 /home/vagrant/.ssh/authorized_keys
 
 	# clean up


### PR DESCRIPTION
The Vagrant documentation for option ``group`` in syncing folders states (in https://www.vagrantup.com/docs/synced-folders/basic_usage.html#group): "By default this will be the SSH user". Vagrant indeed tries to change the owner and group of synchronized files to ``vagrant:vagrant`` (not ``vagrant:users``). It outputs:

    The following SSH command responded with a non-zero exit status.
    Vagrant assumes that this means the command failed!

    find /vagrant '!' -type l -a '(' ! -user vagrant -or ! -group vagrant
    ')' -exec chown vagrant:vagrant '{}' +

    Stdout from the command:

    Stderr from the command:

    find: 'vagrant' is not the name of an existing group

Fix this by using ``--user-group`` instead of ``--gid users`` in the ``useradd`` command which creates user ``vagrant``.