### PR TITLE
Fix wrapper download iso url and update to April 2017 ISO

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2017.03.01/archlinux-2017.03.01-dual.iso",
-        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/2017.03.01/sha1sums.txt",
+        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2017.04.01/archlinux-2017.04.01-x86_64.iso",
+        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/2017.04.01/sha1sums.txt",
         "iso_checksum_type": "sha1",
         "ssh_timeout": "20m",
         "country": "US",

--- a/wrapacker
+++ b/wrapacker
@@ -244,7 +244,7 @@ else
 fi
 
 ISO_CHECKSUM_URL="${MIRROR}/iso/latest/sha1sums.txt"
-ISO_NAME=$(curl -s "$ISO_CHECKSUM_URL" | awk '/dual.iso/{ print $2 }')
+ISO_NAME=$(curl -s "$ISO_CHECKSUM_URL" | awk '/-x86_64.iso/{ print $2 }')
 ISO_URL="${MIRROR}/iso/latest/${ISO_NAME}"
 
 if [[ $timeout ]]; then


### PR DESCRIPTION
It seems the archlinux dropped support for dual iso.
According the official mirror (and many other which I have checked)
there is only -x86_64.iso file.
You can see it here: https://mirrors.kernel.org/archlinux/iso/latest/
This fix will ensure that the correct signature is read when the image
is parsed in sha1sum.txt file.