### PR TITLE
Set expect_disconnect to "true" to fix build

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -98,6 +98,7 @@
         {
             "type": "shell",
             "execute_command": "{{ .Vars }} COUNTRY={{ user `country` }} sudo -E -S bash '{{ .Path }}'",
+            "expect_disconnect": true,
             "script": "scripts/install-base.sh"
         },
         {


### PR DESCRIPTION
Based on https://www.packer.io/docs/provisioners/shell.html#expect_disconnect and local test, expect_disconnect in shell provisioner is not true by default anymore, so when install-base tries to reboot machine, installation fails.