### PR TITLE
Install Open VM Tools

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -114,6 +114,12 @@
             "script": "scripts/install-virtualbox.sh"
         },
         {
+            "only": ["vmware-iso"],
+            "type": "shell",
+            "execute_command": "{{ .Vars }} sudo -E -S bash '{{ .Path }}'",
+            "script": "scripts/install-vmware.sh"
+        },
+        {
             "type": "shell",
             "execute_command": "{{ .Vars }} sudo -E -S bash '{{ .Path }}'",
             "script": "scripts/cleanup.sh"

--- a/scripts/install-vmware.sh
+++ b/scripts/install-vmware.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash -x
+
+# Open VM Tools
+# https://wiki.archlinux.org/index.php/VMware
+# https://wiki.archlinux.org/index.php/VMware/Installing_Arch_as_a_guest
+/usr/bin/pacman -S --noconfirm linux-headers open-vm-tools nfs-utils
+
+/usr/bin/systemctl enable vmtoolsd.service
+/usr/bin/systemctl enable rpcbind.service


### PR DESCRIPTION
I've had some problems creating an Arch Linux VM with VMware Fusion and Vagrant this last couple of weeks, and it appears the errors stems from Vagrant expecting VMware Tools being present in the VM.

I'm blocked on testing this as VMware Fusion 11 has just dropped and Vagrant doesn't yet support it. Sharing in case it's valuable to someone else.