### PR TITLE
Use Packer Template feature to auto-populate ISOs

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -122,7 +122,7 @@
     "post-processors": [
         {
             "type": "vagrant",
-            "output": "output/packer_arch_{{ .Provider }}-{{isotime \"2006.01.02\"}}.box"
+            "output": "output/packer_arch_{{ .Provider }}-{{isotime \"2006.01\"}}.01.box"
         }
     ]
 }

--- a/arch-template.json
+++ b/arch-template.json
@@ -1,7 +1,7 @@
 {
     "variables": {
-        "iso_url": "https://mirrors.kernel.org/archlinux/iso/2018.10.01/archlinux-2018.10.01-x86_64.iso",
-        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/2018.10.01/sha1sums.txt",
+        "iso_url": "https://mirrors.kernel.org/archlinux/iso/{{isotime \"2006.01\"}}.01/archlinux-{{isotime \"2006.01\"}}.01-x86_64.iso",
+        "iso_checksum_url": "https://mirrors.kernel.org/archlinux/iso/{{isotime \"2006.01\"}}.01/sha1sums.txt",
         "iso_checksum_type": "sha1",
         "ssh_timeout": "20m",
         "country": "US",
@@ -122,7 +122,7 @@
     "post-processors": [
         {
             "type": "vagrant",
-            "output": "output/packer_arch_{{ .Provider }}.box"
+            "output": "output/packer_arch_{{ .Provider }}-{{isotime \"2006.01.02\"}}.box"
         }
     ]
 }


### PR DESCRIPTION
## Background:

Current implementation of the arch template file requires that the ISO URL and SHA sum URL be updated monthly to remain in sync with current release.

## Implementation in this PR

Packer template variables allow for dynamic integration of variables 
within the template.
This Pull Request leverages the [`isotime` template engine](https://www.packer.io/docs/templates/engine.html#isotime-function-format-reference) to auto generate
the year and month values for the ISO url as well as the SHA checksum
fields.

This will allow for the ISO image to continuously remain up-to-date
without the need for continued monthly commits.

Additionally, it leverages this same template variable to ensure that
the resulting box filename matches the date it was created, for archival
purposes.

## Possible Issues:

There are two potential issues that I can see with this implementation:

1. The past several months have all followed the `yyyy.mm.01` format, indicating their build date, as seen here: https://mirrors.edge.kernel.org/archlinux/iso/
This can cause an issue if there is an upstream build problem, resulting in the ISO being released on a day not on the first of the month (e.g. `2018.10.02`)
2. The end user attempts to build this packer image on the first of the month immediately before upstream Arch ISO maintainers post that month's image.