### PR TITLE
Fix a handful of spooky wrapacker bugs

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -2,7 +2,6 @@
 
 # Clean the pacman cache.
 /usr/bin/yes | /usr/bin/pacman -Scc
-/usr/bin/pacman-optimize
 
 # Write zeros to improve virtual disk compaction.
 zerofile=$(/usr/bin/mktemp /zerofile.XXXXX)

--- a/wrapacker
+++ b/wrapacker
@@ -17,8 +17,8 @@
 # country codes supported by https://www.archlinux.org/mirrorlist/
 readonly VALID_COUNTRIES=(AT AU BD BE BG BR BY CA CH CL CN CO CZ DE DK EC ES FR GB GR HR HU ID IE IL IN IR IS IT JP KR KZ LT LU LV MK NC NL NO NZ PH PL PT RO RS RU SE SG SK TR TW UA US VN ZA)
 
-# use the correct binary if running from arch linux
-if [[ -f /etc/arch-release ]]; then
+if command -v packer-io > /dev/null 2>&1; then
+	# Older arch linux versions called the packer binary packer-io.
 	readonly PACKER_BIN='packer-io'
 else
 	readonly PACKER_BIN='packer'

--- a/wrapacker
+++ b/wrapacker
@@ -244,7 +244,7 @@ else
 fi
 
 ISO_CHECKSUM_URL="${MIRROR}/iso/latest/sha1sums.txt"
-ISO_NAME=$(curl -s "$ISO_CHECKSUM_URL" | awk '/-x86_64.iso/{ print $2 }')
+ISO_NAME=$(curl -sL "$ISO_CHECKSUM_URL" | awk '/-x86_64.iso/{ print $2 }')
 ISO_URL="${MIRROR}/iso/latest/${ISO_NAME}"
 
 if [[ $timeout ]]; then


### PR DESCRIPTION
Please excuse the Halloween-themed issue title. Let me know if you prefer separate pull requests for each commit.

The commits in this pull request are meant to address the following three issues:

1. The pacman-optimize script has been removed from pacman, so don't call it in cleanup.sh.
2. mirrors.kernel.org is redirecting me to mirrors.edge.kernel.org, so I needed to tell curl to follow redirects when fetching the ISO checksums file in wrapacker.
3. In recent versions of Arch Linux, the packer-io package and binary have been renamed to just "packer"; hence, don't set `PACKER_BIN` to packer-io unless that command is actually available.

See the individual commit messages for more info.

I've verified that the virtualbox provider builds and I'm able to `vagrant ssh` into the box. The size of the resulting box file is 574M. I haven't tested any other providers.