### PR TITLE
Turn network interfaces down before restart

### DIFF
--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -99,4 +99,8 @@ echo '==> Adding workaround for shutdown race condition'
 echo '==> Installation complete!'
 /usr/bin/sleep 3
 /usr/bin/umount ${TARGET_DIR}
+# Turning network interfaces down to make sure SSH session was dropped on host.
+# More info at: https://www.packer.io/docs/provisioners/shell.html, section - Handling reboots
+echo '==> Turning down network interfaces and rebooting'
+for i in $(/usr/bin/netstat -i | /usr/bin/tail +3 | /usr/bin/awk '{print $1}'); do /usr/bin/ip link set ${i} down; done
 /usr/bin/systemctl reboot


### PR DESCRIPTION
Turning network interfaces down to make sure SSH session was dropped on host side. More info [here](https://www.packer.io/docs/provisioners/shell.html#handling-reboots)

For me this was the reason of following error:

``Build 'qemu' errored: Error removing temporary script at /tmp/script_3875.sh: ssh: handshake failed: read tcp 127.0.0.1:56048->127.0.0.1:3697: read: connection reset by pee
r``

I couldn't find interface for managing the network in "archiso". It wasn't enabled via systemd so that's why I'm doing it old fashioned and secure way with ip link <dev> down