### PR TITLE
Remove www prefix for ArchLinux  mirror list generator URL

### DIFF
--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -19,7 +19,7 @@ CONFIG_SCRIPT='/usr/local/bin/arch-config.sh'
 ROOT_PARTITION="${DISK}1"
 TARGET_DIR='/mnt'
 COUNTRY=${COUNTRY:-US}
-MIRRORLIST="https://www.archlinux.org/mirrorlist/?country=${COUNTRY}&protocol=http&protocol=https&ip_version=4&use_mirror_status=on"
+MIRRORLIST="https://archlinux.org/mirrorlist/?country=${COUNTRY}&protocol=http&protocol=https&ip_version=4&use_mirror_status=on"
 
 echo ">>>> install-base.sh: Clearing partition table on ${DISK}.."
 /usr/bin/sgdisk --zap ${DISK}


### PR DESCRIPTION
Otherwise, previous MIRRORLIST page should response 301 Moved Permanently.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>