### PR TITLE
Use `openssl passwd -6` instead of `-crypt`

### DIFF
--- a/srv/enable-ssh.sh
+++ b/srv/enable-ssh.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-PASSWORD=$(/usr/bin/openssl passwd -crypt 'vagrant')
+PASSWORD="$(/usr/bin/openssl passwd -6 'vagrant')"
 
 # Vagrant-specific configuration
-/usr/bin/useradd --password ${PASSWORD} --comment 'Vagrant User' --create-home --user-group vagrant
+/usr/bin/useradd --password "${PASSWORD}" --comment 'Vagrant User' --create-home --user-group vagrant
 echo -e 'vagrant\nvagrant' | /usr/bin/passwd vagrant
 echo 'Defaults env_keep += "SSH_AUTH_SOCK"' > /etc/sudoers.d/10_vagrant
 echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/10_vagrant


### PR DESCRIPTION
OpenSSL 3.0 removed option `-crypt`. Use `-6` as this option seems unlikely to be removed soon.

While at it, quote shell variables in a safe way to prevent issues when they contain space characters.

Fixes: https://github.com/elasticdog/packer-arch/issues/80