### PR TITLE
Use 1GB memory in when installing Arch Linux ISO

### DIFF
--- a/arch-template.json
+++ b/arch-template.json
@@ -24,7 +24,7 @@
                 "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "cpus": 1,
-            "memory": 768,
+            "memory": 1024,
             "disk_size": 20480,
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -46,7 +46,7 @@
                 "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "cpus": 1,
-            "memory": 768,
+            "memory": 1024,
             "disk_size": 20480,
             "hard_drive_interface": "sata",
             "ssh_username": "vagrant",
@@ -68,7 +68,7 @@
                 "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "cpus": 1,
-            "memory": 768,
+            "memory": 1024,
             "disk_size": 20480,
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",
@@ -89,7 +89,7 @@
                 "/usr/bin/bash ./enable-ssh.sh<enter>"
             ],
             "cpus": 1,
-            "memory": 768,
+            "memory": 1024,
             "disk_size": 20480,
             "ssh_username": "vagrant",
             "ssh_password": "vagrant",


### PR DESCRIPTION
Booting the Arch Linux ISO nowadays requires at least 955 MB of memory (from running `free -m` after booting it in VirtualBox).

When the virtual machine only has 768 MB of RAM, extracting the initrd fails and the provisioning script aborts.

Increase the memory to 1024 MB to fix this.