### PR TITLE
Start systemd-resolved automatically

### DIFF
--- a/scripts/install-base.sh
+++ b/scripts/install-base.sh
@@ -80,6 +80,7 @@ cat <<-EOF > "${TARGET_DIR}${CONFIG_SCRIPT}"
   # https://wiki.archlinux.org/index.php/Network_configuration#Revert_to_traditional_interface_names
   /usr/bin/ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
   /usr/bin/systemctl enable dhcpcd@eth0.service
+  /usr/bin/systemctl enable systemd-resolved.service
   echo ">>>> ${CONFIG_SCRIPT_SHORT}: Configuring sshd.."
   /usr/bin/sed -i 's/#UseDNS yes/UseDNS no/' /etc/ssh/sshd_config
   /usr/bin/systemctl enable sshd.service


### PR DESCRIPTION
When dhcpcd receives a DHCP lease, it tries to configure the DNS servers through a D-Bus call to systemd-resolved, which currently fails. Fix this by enabling the relevant systemd unit.